### PR TITLE
atomWithHash applies hash URL value before applying initial value

### DIFF
--- a/__tests__/atomWithHash_spec.tsx
+++ b/__tests__/atomWithHash_spec.tsx
@@ -186,6 +186,34 @@ describe('atomWithHash', () => {
     await user.type(screen.getByLabelText('b'), '1');
     await waitFor(() => expect(paramBMockFn).toBeCalledTimes(4));
   });
+
+  it('initializes with existing value if it exists within the hash', async () => {
+    window.location.hash = '#count=2';
+
+    const countAtom = atomWithHash('count', 1, { setHash: 'replaceState' });
+
+    const Counter = () => {
+      const [count, setCount] = useAtom(countAtom);
+      return (
+        <>
+          <div>count: {count}</div>
+          <button type="button" onClick={() => setCount((c) => c + 1)}>
+            button
+          </button>
+        </>
+      );
+    };
+
+    const { findByText } = render(
+      <StrictMode>
+        <Counter />
+      </StrictMode>,
+    );
+
+    expect(window.location.hash).toEqual('#count=2');
+
+    await findByText('count: 2');
+  });
 });
 
 describe('atomWithHash without window', () => {

--- a/src/atomWithHash.ts
+++ b/src/atomWithHash.ts
@@ -111,5 +111,11 @@ export function atomWithHash<Value>(
     },
   };
 
-  return atomWithStorage(key, initialValue, hashStorage);
+  const establishedValue = hashStorage.getItem(key);
+
+  return atomWithStorage(
+    key,
+    establishedValue === NO_STORAGE_VALUE ? initialValue : establishedValue,
+    hashStorage,
+  );
 }


### PR DESCRIPTION
Related to #10  - Retrieves the true initial value from the URL hash prior to applying the user specified initial value. This way, if the initial value exists at its true source, it will be applied first.