### PR TITLE
fix(atomWithHash): replaceState function to use window.history.state instead of null

### DIFF
--- a/src/atomWithHash.ts
+++ b/src/atomWithHash.ts
@@ -34,7 +34,7 @@ export function atomWithHash<Value>(
   if (setHashOption === 'replaceState') {
     setHash = (searchParams) => {
       window.history.replaceState(
-        null,
+        window.history.state,
         '',
         `${window.location.pathname}${window.location.search}#${searchParams}`,
       );


### PR DESCRIPTION

My project uses the new NextJS app router, and we were using atomWithHash to keep track of state. This was breaking when used with the app router when using the back button in the browser. In my project I am just setting the setHash function to do what I committed here. I figured it would be better and easier for anyone else using this library to just set the flag replaceState if they are using the nextjs app router. (Maybe the website/documentation should be updated as well.)