### PR TITLE
bump node version in codesandbox ci

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
   "buildCommand": "compile",
   "sandboxes": ["new", "react-typescript-react-ts"],
-  "node": "14"
+  "node": "18"
 }


### PR DESCRIPTION
Node version for codesandbox is too low for pnpm. Bumping it to match github action node version.