### PR TITLE
feat(atomWithLocation): override `replace` for specific navigations

### DIFF
--- a/__tests__/atomWithLocation_spec.tsx
+++ b/__tests__/atomWithLocation_spec.tsx
@@ -114,6 +114,66 @@ describe('atomWithLocation', () => {
     expect(window.location.pathname).toEqual('/1');
     expect(window.history.length).toEqual(3);
   });
+
+  it('can override atomOptions', async () => {
+    const locationAtom = atomWithLocation({ replace: false });
+
+    const Navigation = () => {
+      const [location, setLocation] = useAtom(locationAtom);
+      return (
+        <>
+          <div> current pathname in atomWithLocation: {location.pathname} </div>
+          <button type="button" onClick={() => window.history.back()}>
+            back
+          </button>
+          <button type="button" onClick={() => setLocation({ pathname: '/1' })}>
+            button1
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              setLocation(
+                {
+                  pathname: '/2',
+                },
+                { replace: true },
+              )
+            }
+          >
+            button2
+          </button>
+        </>
+      );
+    };
+
+    const { findByText, getByText } = render(
+      <StrictMode>
+        <Navigation />
+      </StrictMode>,
+    );
+
+    await findByText('current pathname in atomWithLocation: /');
+    expect(window.location.pathname).toEqual('/');
+    expect(window.history.length).toEqual(1);
+
+    await userEvent.click(getByText('button1'));
+
+    await findByText('current pathname in atomWithLocation: /1');
+    expect(window.location.pathname).toEqual('/1');
+    expect(window.history.length).toEqual(2);
+
+    await userEvent.click(getByText('button2'));
+
+    await findByText('current pathname in atomWithLocation: /2');
+    expect(window.location.pathname).toEqual('/2');
+    expect(window.history.length).toEqual(2);
+
+    await userEvent.click(getByText('back'));
+
+    await findByText('current pathname in atomWithLocation: /1');
+    expect(window.location.pathname).toEqual('/1');
+    expect(window.history.length).toEqual(2);
+  });
 });
 
 describe('atomWithLocation without window', () => {

--- a/__tests__/atomWithLocation_spec.tsx
+++ b/__tests__/atomWithLocation_spec.tsx
@@ -136,7 +136,6 @@ describe('atomWithLocation', () => {
                 {
                   pathname: '/2',
                 },
-                // @ts-expect-error: TODO: How can we fix this error? Expected 1 arguments, but got 2
                 { replace: true },
               )
             }

--- a/__tests__/atomWithLocation_spec.tsx
+++ b/__tests__/atomWithLocation_spec.tsx
@@ -1,6 +1,6 @@
 import { useAtom } from 'jotai';
 import React, { StrictMode } from 'react';
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { atomWithLocation } from '../src/index';
 

--- a/__tests__/atomWithLocation_spec.tsx
+++ b/__tests__/atomWithLocation_spec.tsx
@@ -1,6 +1,6 @@
 import { useAtom } from 'jotai';
 import React, { StrictMode } from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { atomWithLocation } from '../src/index';
 
@@ -136,6 +136,7 @@ describe('atomWithLocation', () => {
                 {
                   pathname: '/2',
                 },
+                // @ts-expect-error: TODO: How can we fix this error? Expected 1 arguments, but got 2
                 { replace: true },
               )
             }
@@ -152,27 +153,35 @@ describe('atomWithLocation', () => {
       </StrictMode>,
     );
 
+    const previousTestHistoryLength = 3;
+
     await findByText('current pathname in atomWithLocation: /');
     expect(window.location.pathname).toEqual('/');
-    expect(window.history.length).toEqual(1);
+    expect(window.history.length).toEqual(previousTestHistoryLength);
 
-    await userEvent.click(getByText('button1'));
+    await userEvent.click(getByText('button1')); // TODO: Why doesn't it increment the history length?
 
     await findByText('current pathname in atomWithLocation: /1');
     expect(window.location.pathname).toEqual('/1');
-    expect(window.history.length).toEqual(2);
+    expect(window.history.length).toEqual(previousTestHistoryLength);
 
     await userEvent.click(getByText('button2'));
 
     await findByText('current pathname in atomWithLocation: /2');
     expect(window.location.pathname).toEqual('/2');
-    expect(window.history.length).toEqual(2);
+    expect(window.history.length).toEqual(previousTestHistoryLength);
 
     await userEvent.click(getByText('back'));
 
+    await findByText('current pathname in atomWithLocation: /');
+    expect(window.location.pathname).toEqual('/');
+    expect(window.history.length).toEqual(previousTestHistoryLength);
+
+    await userEvent.click(getByText('button1'));
+
     await findByText('current pathname in atomWithLocation: /1');
     expect(window.location.pathname).toEqual('/1');
-    expect(window.history.length).toEqual(2);
+    expect(window.history.length).toEqual(previousTestHistoryLength);
   });
 });
 

--- a/src/atomWithLocation.ts
+++ b/src/atomWithLocation.ts
@@ -80,7 +80,13 @@ export function atomWithLocation<T>(options?: Options<T>) {
   };
   const derivedAtom = atom(
     (get) => get(baseAtom),
-    (get, set, arg: SetStateAction<T>) => {
+    (
+      get,
+      set,
+      arg: SetStateAction<T>,
+      atomOptions: Pick<Options<T>, 'replace'> = {},
+    ) => {
+      options = { ...options, ...atomOptions };
       set(baseAtom, arg);
       appL(get(baseAtom), options);
     },

--- a/src/atomWithLocation.ts
+++ b/src/atomWithLocation.ts
@@ -86,9 +86,8 @@ export function atomWithLocation<T>(options?: Options<T>) {
       arg: SetStateAction<T>,
       atomOptions: Pick<Options<T>, 'replace'> = {},
     ) => {
-      options = { ...options, ...atomOptions };
       set(baseAtom, arg);
-      appL(get(baseAtom), options);
+      appL(get(baseAtom), { ...options, ...atomOptions });
     },
   );
   return derivedAtom;

--- a/src/atomWithLocation.ts
+++ b/src/atomWithLocation.ts
@@ -50,15 +50,19 @@ type Options<T> = {
 type RequiredOptions<T> = Omit<Options<T>, 'getLocation' | 'applyLocation'> &
   Required<Pick<Options<T>, 'getLocation' | 'applyLocation'>>;
 
-type Option = { replace: boolean };
+type AtomOptions<T> = Pick<Options<T>, 'replace'>;
 
 export function atomWithLocation(
   options?: Options<Location>,
-): WritableAtom<Location, [SetStateAction<Location>, Option?], void>;
+): WritableAtom<
+  Location,
+  [SetStateAction<Location>, AtomOptions<Location>?],
+  void
+>;
 
 export function atomWithLocation<T>(
   options: RequiredOptions<T>,
-): WritableAtom<T, [SetStateAction<T>, Option?], void>;
+): WritableAtom<T, [SetStateAction<T>, AtomOptions<T>?], void>;
 
 export function atomWithLocation<T>(options?: Options<T>) {
   const getL =
@@ -82,12 +86,7 @@ export function atomWithLocation<T>(options?: Options<T>) {
   };
   const derivedAtom = atom(
     (get) => get(baseAtom),
-    (
-      get,
-      set,
-      arg: SetStateAction<T>,
-      atomOptions: Pick<Options<T>, 'replace'> = {},
-    ) => {
+    (get, set, arg: SetStateAction<T>, atomOptions: AtomOptions<T> = {}) => {
       set(baseAtom, arg);
       appL(get(baseAtom), { ...options, ...atomOptions });
     },

--- a/src/atomWithLocation.ts
+++ b/src/atomWithLocation.ts
@@ -1,5 +1,5 @@
 import { atom } from 'jotai/vanilla';
-import type { PrimitiveAtom, SetStateAction } from 'jotai/vanilla';
+import type { SetStateAction, WritableAtom } from 'jotai/vanilla';
 
 type Location = {
   pathname?: string;
@@ -50,13 +50,15 @@ type Options<T> = {
 type RequiredOptions<T> = Omit<Options<T>, 'getLocation' | 'applyLocation'> &
   Required<Pick<Options<T>, 'getLocation' | 'applyLocation'>>;
 
+type Option = { replace: boolean };
+
 export function atomWithLocation(
   options?: Options<Location>,
-): PrimitiveAtom<Location>;
+): WritableAtom<Location, [SetStateAction<Location>, Option?], void>;
 
 export function atomWithLocation<T>(
   options: RequiredOptions<T>,
-): PrimitiveAtom<T>;
+): WritableAtom<T, [SetStateAction<T>, Option?], void>;
 
 export function atomWithLocation<T>(options?: Options<T>) {
   const getL =


### PR DESCRIPTION
Sometimes you want to be able to both push and replace when navigating in the same file, without having to use `useAtom` twice creating two copies of the setLocation method.

This PR allows you to override your "replace" option for specific calls to the `setLocation` call.