### PR TITLE
feat(atomWithHash):  initial value from hash

### DIFF
--- a/__tests__/atomWithHash_spec.tsx
+++ b/__tests__/atomWithHash_spec.tsx
@@ -1,4 +1,4 @@
-import React, { StrictMode, useMemo } from 'react';
+import React, { StrictMode, useEffect, useMemo, useState } from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useAtom } from 'jotai/react';
@@ -185,6 +185,37 @@ describe('atomWithHash', () => {
 
     await user.type(screen.getByLabelText('b'), '1');
     await waitFor(() => expect(paramBMockFn).toBeCalledTimes(4));
+  });
+
+  it('sets initial value from hash', async () => {
+    window.location.hash = '#count=2';
+    const countAtom = atomWithHash('count', 0);
+
+    const Counter = () => {
+      const [count] = useAtom(countAtom);
+      const [countWasZero, setCountWasZero] = useState(false);
+
+      useEffect(() => {
+        if (count === 0) {
+          setCountWasZero(true);
+        }
+      }, [count]);
+      return (
+        <>
+          <div>count: {count}</div>
+          <div>count was zero: {countWasZero.toString()}</div>
+        </>
+      );
+    };
+
+    const { findByText } = render(
+      <StrictMode>
+        <Counter />
+      </StrictMode>,
+    );
+
+    await findByText('count: 2');
+    await findByText('count was zero: false');
   });
 });
 

--- a/src/atomWithHash.ts
+++ b/src/atomWithHash.ts
@@ -26,12 +26,7 @@ export function atomWithHash<Value>(
   },
 ): WritableAtom<Value, [SetStateActionWithReset<Value>], void> {
   const serialize = options?.serialize || JSON.stringify;
-  let initialValueInHash: string | null = null;
-  if (typeof window !== 'undefined') {
-    initialValueInHash = new URLSearchParams(window.location.hash.slice(1)).get(
-      key,
-    );
-  }
+
   const deserialize = options?.deserialize || safeJSONParse(initialValue);
   const subscribe =
     options?.subscribe ||
@@ -57,15 +52,20 @@ export function atomWithHash<Value>(
   if (typeof setHashOption === 'function') {
     setHash = setHashOption;
   }
-  const strAtom = atom(initialValueInHash);
+  const isLocationAvailable =
+    typeof window !== 'undefined' && !!window.location;
+
+  const strAtom = atom(
+    isLocationAvailable
+      ? new URLSearchParams(window.location.hash.slice(1)).get(key)
+      : null,
+  );
   strAtom.onMount = (setAtom) => {
-    if (typeof window === 'undefined' || !window.location) {
+    if (!isLocationAvailable) {
       return undefined;
     }
     const callback = () => {
-      const searchParams = new URLSearchParams(window.location.hash.slice(1));
-      const str = searchParams.get(key);
-      setAtom(str);
+      setAtom(new URLSearchParams(window.location.hash.slice(1)).get(key));
     };
     const unsubscribe = subscribe(callback);
     callback();

--- a/src/atomWithHash.ts
+++ b/src/atomWithHash.ts
@@ -26,6 +26,12 @@ export function atomWithHash<Value>(
   },
 ): WritableAtom<Value, [SetStateActionWithReset<Value>], void> {
   const serialize = options?.serialize || JSON.stringify;
+  let hashValueInURL;
+  if (global.window) {
+    hashValueInURL = new URLSearchParams(window.location.hash.slice(1)).get(
+      key,
+    );
+  }
   const deserialize = options?.deserialize || safeJSONParse(initialValue);
   const subscribe =
     options?.subscribe ||
@@ -51,7 +57,7 @@ export function atomWithHash<Value>(
   if (typeof setHashOption === 'function') {
     setHash = setHashOption;
   }
-  const strAtom = atom<string | null>(null);
+  const strAtom = atom<string | null>(hashValueInURL ?? null);
   strAtom.onMount = (setAtom) => {
     if (typeof window === 'undefined' || !window.location) {
       return undefined;

--- a/src/atomWithHash.ts
+++ b/src/atomWithHash.ts
@@ -26,9 +26,9 @@ export function atomWithHash<Value>(
   },
 ): WritableAtom<Value, [SetStateActionWithReset<Value>], void> {
   const serialize = options?.serialize || JSON.stringify;
-  let hashValueInURL;
-  if (global.window) {
-    hashValueInURL = new URLSearchParams(window.location.hash.slice(1)).get(
+  let initialValueInHash: string | null = null;
+  if (typeof window !== 'undefined') {
+    initialValueInHash = new URLSearchParams(window.location.hash.slice(1)).get(
       key,
     );
   }
@@ -57,7 +57,7 @@ export function atomWithHash<Value>(
   if (typeof setHashOption === 'function') {
     setHash = setHashOption;
   }
-  const strAtom = atom<string | null>(hashValueInURL ?? null);
+  const strAtom = atom(initialValueInHash);
   strAtom.onMount = (setAtom) => {
     if (typeof window === 'undefined' || !window.location) {
       return undefined;


### PR DESCRIPTION
Added a test that triggers the problem mentioned in #10, if I read that issue correctly. 
That test is added in 5f4e4c11c6db779015cf22f696d06348645c6ec0


To fix that test, if a hash value with matching key is present in the url then it will used as the inital value for the `strAtom`, which results in the first render not using the otherwise defined `initialValue`.