### PR TITLE
fix(atomWithLocation): replaceState function to use window.history.state instead of null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 
 ## [Unreleased]
-- feat(atomWithLocation): support location.hash
+- feat(atomWithLocation): support location.hash #30
+- fix(atomWithLocation): replaceState function to use window.history.state instead of null #33
 
 ## [0.5.4] - 2024-02-27
 ### Changed

--- a/src/atomWithLocation.ts
+++ b/src/atomWithLocation.ts
@@ -33,7 +33,7 @@ const applyLocation = (
     url.hash = location.hash;
   }
   if (options?.replace) {
-    window.history.replaceState(null, '', url);
+    window.history.replaceState(window.history.state, '', url);
   } else {
     window.history.pushState(null, '', url);
   }


### PR DESCRIPTION
Work mentioned here: https://github.com/jotaijs/jotai-location/pull/24#issuecomment-1803865047