### PR TITLE
Improve atomWithSearchParams

### DIFF
--- a/examples/05_serch_params/src/app.tsx
+++ b/examples/05_serch_params/src/app.tsx
@@ -1,9 +1,9 @@
 import { atomWithSearchParams } from 'jotai-location';
 import { useAtom } from 'jotai/react';
 
-const oneAtom = atomWithSearchParams<number>('one', 0);
-const twoAtom = atomWithSearchParams<number>('two', 0);
-const threeAtom = atomWithSearchParams<number>('three', 0);
+const oneAtom = atomWithSearchParams('one', 0);
+const twoAtom = atomWithSearchParams('two', 0);
+const threeAtom = atomWithSearchParams('three', 0);
 
 const Page = () => {
   const [one, setOne] = useAtom(oneAtom);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,5 @@
+export function warning(...data: unknown[]) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(...data);
+  }
+}

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -1,0 +1,7 @@
+export type ResolvePrimitive<T> = T extends string
+  ? string
+  : T extends number
+    ? number
+    : T extends boolean
+      ? boolean
+      : never;

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -1,7 +1,0 @@
-export type ResolvePrimitive<T> = T extends string
-  ? string
-  : T extends number
-    ? number
-    : T extends boolean
-      ? boolean
-      : never;

--- a/tests/atomWithSearchParams.spec.tsx
+++ b/tests/atomWithSearchParams.spec.tsx
@@ -18,9 +18,9 @@ describe('atomWithSearchParams', () => {
   });
 
   it('handles different value types', async () => {
-    const stringAtom = atomWithSearchParams<string>('string', 'default');
-    const numberAtom = atomWithSearchParams<number>('number', 0);
-    const booleanAtom = atomWithSearchParams<boolean>('boolean', false);
+    const stringAtom = atomWithSearchParams('string', 'default');
+    const numberAtom = atomWithSearchParams('number', 0);
+    const booleanAtom = atomWithSearchParams('boolean', false);
 
     const Navigation = () => {
       const [stringValue, setStringValue] = useAtom(stringAtom);
@@ -72,7 +72,7 @@ describe('atomWithSearchParams', () => {
   });
 
   it('handles function updates', async () => {
-    const searchParamAtom = atomWithSearchParams<number>('count', 0);
+    const searchParamAtom = atomWithSearchParams('count', 0);
 
     const Navigation = () => {
       const [value, setValue] = useAtom(searchParamAtom);


### PR DESCRIPTION
related #52 

### Changes

1. improve applyLocation func
2. improve generic type inference

### Discussion

Currently, when using atomWithSearchParams("key", 0), the atom type is fixed to 0 instead of being inferred as a number, which causes inconvenient type inference.
To improve this, I changed the method to use ResolvePrimitive to enable type inference. However, this caused the resolveValue method to use an assertion of the form "as unknown as PrimitiveType" because the PrimitiveType and generic T types are different.

Is there a cleaner way to solve this?
